### PR TITLE
Fixed typo in TemplateCommand.vm

### DIFF
--- a/templates/TemplateCommand.vm
+++ b/templates/TemplateCommand.vm
@@ -1,4 +1,4 @@
-w#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
 #parse("File Header.java")
 
 import java.util.List;


### PR DESCRIPTION
There was a "w" at the beginning of the file that caused IDE errors and a doubling of the package declaration.